### PR TITLE
Improved: code to use enter instead of input for Timezone search (#2cj8zmd).

### DIFF
--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -9,7 +9,7 @@
       <ion-title>{{ $t("Select time zone") }}</ion-title>
     </ion-toolbar>
     <ion-toolbar>
-      <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search time zones')"  v-model="queryString" @ionInput="findTimeZone()"></ion-searchbar>
+      <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search time zones')"  v-model="queryString" v-on:keyup.enter="findTimeZone()"></ion-searchbar>
     </ion-toolbar>
   </ion-header>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
:- Worked on improving the code to use keyUp event for enter button instead of 'ionInput' for timeZone search.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)