### PR TITLE
Fixed: Reseting reverts to wrong info(#2yma5bp)

### DIFF
--- a/src/components/ProductPopover.vue
+++ b/src/components/ProductPopover.vue
@@ -69,7 +69,7 @@ export default defineComponent({
       const items = this.ordersList.items.map(element => {
         if(element.parentProductId === this.id) {
           const item = original.find(item => {
-            return item.parentProductId === this.id;
+            return item.parentProductId === this.id && item.shopifyProductSKU === element.shopifyProductSKU;
           })
           element = item;
         }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #74 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When reverting a parent product, all the child products are changed to the first child element. 
Updated the code to filter items based on parentProductId as well as productSKU for correct data.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)