### PR TITLE
Implemented logic to display an alert before route change(#2ymay5f)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -15,7 +15,7 @@
                 router-direction="root"
                 :router-link="p.url"
                 class="hydrated"
-                :class="{ selected: selectedIndex === i }"
+                :class="{ selected: selectedIndex === i && this.$route.path === p.url }"
               >
                 <ion-icon slot="start" :ios="p.iosIcon" :md="p.mdIcon"></ion-icon>
                 <ion-label>{{ p.title }}</ion-label>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" @click="navigateBack" default-href="/purchase-order" />
+        <ion-back-button slot="start" default-href="/purchase-order" />
         <ion-title>{{ orderId }}</ion-title>
         <ion-buttons slot="end">
           <ion-button @click="selectAllItems">
@@ -245,26 +245,7 @@ export default defineComponent({
         componentProps: { 'unidentifiedProductItems': this.ordersList.unidentifiedProductItems }
       });
       return missingSkuModal.present();
-    },
-    async navigateBack(){
-      const alert = await alertController.create({
-        header: this.$t("Leave page"),
-        message: this.$t("Any edits made to this PO will be lost."),
-        buttons: [
-            {
-              text: this.$t("STAY"),
-              role: 'cancel',
-            },
-            {
-              text: this.$t("LEAVE"),
-              handler: () => {
-                this.router.push("/purchase-order");
-              },
-            },
-          ],
-      });
-      return alert.present();
-    },  
+    }, 
     searchProduct(sku: any) {
       const product = this.getProduct(sku);
       this.searchedProduct = this.ordersList.items.find((item: any) => {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -209,29 +209,29 @@ export default defineComponent({
       canLeave: false
     }
   },
-  // ionViewDidEnter(){
-  //  this.fetchFacilities();
-  // },
+  ionViewDidEnter(){
+   this.fetchFacilities();
+  },
   // async ionViewWillLeave(){
   //   const alert = await alertController.create({
-  //       header: this.$t("Leave page"),
-  //       message: this.$t("Any edits made to this PO will be lost."),
+  //       header: "Leave page",
+  //       message: "Any edits made to this PO will be lost.",
   //       buttons: [
   //           {
-  //             text: this.$t("STAY"),
+  //             text: "STAY",
   //             handler: () => {
-  //               this.router.push("/purchase-order-detail")
+  //               return false;
   //             },
   //           },
   //           {
-  //             text: this.$t("LEAVE"),
+  //             text: "LEAVE",
   //             handler: () => {
-  //               this.router.push() 
+  //               return true;
   //             },
   //           },
   //         ],
   //     });
-  //     return alert.present();
+  //     alert.present();
   // },
   async beforeRouteLeave(to, from) {
     const alert = await alertController.create({
@@ -240,20 +240,25 @@ export default defineComponent({
         buttons: [
             {
               text: this.$t("STAY"),
-              handler: () => {
-                this.router.push(from)
-              },
+              role: 'cancel',
             },
             {
               text: this.$t("LEAVE"),
               handler: () => {
-                this.router.push(to) 
+                return true; 
               },
             },
           ],
       });
-      return alert.present();
+      await alert.present();
+      await alert.onDidDismiss();
+
+      // return this.canLeave;
+      // alert.onDidDismiss().then(() => {
+      //   return this.canLeave;
+      // });
   },
+  
   methods: {
     async listMissingSkus() {
       const missingSkuModal = await modalController.create({

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -212,27 +212,6 @@ export default defineComponent({
   ionViewDidEnter(){
    this.fetchFacilities();
   },
-  // async ionViewWillLeave(){
-  //   const alert = await alertController.create({
-  //       header: "Leave page",
-  //       message: "Any edits made to this PO will be lost.",
-  //       buttons: [
-  //           {
-  //             text: "STAY",
-  //             handler: () => {
-  //               return false;
-  //             },
-  //           },
-  //           {
-  //             text: "LEAVE",
-  //             handler: () => {
-  //               return true;
-  //             },
-  //           },
-  //         ],
-  //     });
-  //     alert.present();
-  // },
   async beforeRouteLeave(to, from) {
     const alert = await alertController.create({
         header: this.$t("Leave page"),
@@ -240,23 +219,22 @@ export default defineComponent({
         buttons: [
             {
               text: this.$t("STAY"),
-              role: 'cancel',
+              handler: () => {
+                this.canLeave = false;
+              },
             },
             {
               text: this.$t("LEAVE"),
               handler: () => {
-                return true; 
+                this.canLeave = true;
               },
             },
           ],
       });
-      await alert.present();
+      alert.present();
       await alert.onDidDismiss();
 
-      // return this.canLeave;
-      // alert.onDidDismiss().then(() => {
-      //   return this.canLeave;
-      // });
+      return (this as any).canLeave;
   },
   
   methods: {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -206,10 +206,53 @@ export default defineComponent({
       facilities: [] as any,
       queryString: "",
       searchedProduct: {} as any,
+      canLeave: false
     }
   },
-  ionViewDidEnter(){
-   this.fetchFacilities();
+  // ionViewDidEnter(){
+  //  this.fetchFacilities();
+  // },
+  // async ionViewWillLeave(){
+  //   const alert = await alertController.create({
+  //       header: this.$t("Leave page"),
+  //       message: this.$t("Any edits made to this PO will be lost."),
+  //       buttons: [
+  //           {
+  //             text: this.$t("STAY"),
+  //             handler: () => {
+  //               this.router.push("/purchase-order-detail")
+  //             },
+  //           },
+  //           {
+  //             text: this.$t("LEAVE"),
+  //             handler: () => {
+  //               this.router.push() 
+  //             },
+  //           },
+  //         ],
+  //     });
+  //     return alert.present();
+  // },
+  async beforeRouteLeave(to, from) {
+    const alert = await alertController.create({
+        header: this.$t("Leave page"),
+        message: this.$t("Any edits made to this PO will be lost."),
+        buttons: [
+            {
+              text: this.$t("STAY"),
+              handler: () => {
+                this.router.push(from)
+              },
+            },
+            {
+              text: this.$t("LEAVE"),
+              handler: () => {
+                this.router.push(to) 
+              },
+            },
+          ],
+      });
+      return alert.present();
   },
   methods: {
     async listMissingSkus() {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -206,7 +206,6 @@ export default defineComponent({
       facilities: [] as any,
       queryString: "",
       searchedProduct: {} as any,
-      canLeave: false,
       isParentProductUpdated: false
     }
   },
@@ -214,6 +213,7 @@ export default defineComponent({
    this.fetchFacilities();
   },
   async beforeRouteLeave(to, from) {
+    let canLeave = false;
     const alert = await alertController.create({
         header: this.$t("Leave page"),
         message: this.$t("Any edits made to this PO will be lost."),
@@ -221,13 +221,13 @@ export default defineComponent({
             {
               text: this.$t("STAY"),
               handler: () => {
-                this.canLeave = false;
+                canLeave = false;
               },
             },
             {
               text: this.$t("LEAVE"),
               handler: () => {
-                this.canLeave = true;
+                canLeave = true;
               },
             },
           ],
@@ -235,7 +235,7 @@ export default defineComponent({
       alert.present();
       await alert.onDidDismiss();
 
-      return (this as any).canLeave;
+      return canLeave;
   },
   
   methods: {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #78 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
If the user switches to another page, like the settings page, while reviewing their PO, when they return to the upload screen they land on the file upload screen which is disorienting.

Implemented a pop up that warns the user that if they switch to another screen while reviewing their PO, that their changes will be lost and they'll have to restart.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

[screen-recorder-fri-nov-04-2022-16-42-17.webm](https://user-images.githubusercontent.com/58461801/199959546-6bc07377-6716-473f-9051-5fa66524d13c.webm)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)