### PR TITLE
Updated the position of file name label (#31fu19p)

### DIFF
--- a/src/views/PurchaseOrder.vue
+++ b/src/views/PurchaseOrder.vue
@@ -10,7 +10,8 @@
     <ion-content>
       <main>
         <ion-item>
-          <ion-label>{{ file.name ? $t("Purchase order") +  file.name : $t('Purchase order') }}</ion-label>
+          <ion-label>{{ $t("Purchase order") }}</ion-label>
+          <ion-label>{{ file.name }}</ion-label>
           <input @change="getFile" ref="file" class="ion-hide" type="file" id="inputFile"/>
           <label for="inputFile">{{ $t("Upload") }}</label>
         </ion-item> 

--- a/src/views/PurchaseOrder.vue
+++ b/src/views/PurchaseOrder.vue
@@ -11,7 +11,7 @@
       <main>
         <ion-item>
           <ion-label>{{ $t("Purchase order") }}</ion-label>
-          <ion-label>{{ file.name }}</ion-label>
+          <ion-label class="ion-text-right ion-padding-end">{{ file.name }}</ion-label>
           <input @change="getFile" ref="file" class="ion-hide" type="file" id="inputFile"/>
           <label for="inputFile">{{ $t("Upload") }}</label>
         </ion-item> 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #79 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
The uploaded file name is not seen clearly. The change moves the file name towards the right, beside the Upload button, improving its visibility. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Import - HotWax Commerce](https://user-images.githubusercontent.com/59442907/203499520-144f5b5d-92f0-4ea1-94c6-82c8cb5ca243.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)