### PR TITLE
Fixed: Create new mapping should not show currently selected mapping name(#326r8mq)

### DIFF
--- a/src/views/PurchaseOrder.vue
+++ b/src/views/PurchaseOrder.vue
@@ -195,7 +195,6 @@ export default defineComponent({
             }
           })
           this.fieldMapping = fieldMapping.mappingPrefValue;
-          this.mappingName = fieldMapping.mappingPrefName; 
         }
       },
     },


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #107 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
To prevent confusion for the user, When applying any mapping, the selected mapping name should not be set to Create new mapping input field.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/62360781/205057928-ab230e9e-5aa9-4ba4-9098-1c7ffd3a03de.mov



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)