### PR TITLE
Fixed: disable logic to use length of content instead of using file variable(#85zrhcq56)

### DIFF
--- a/src/views/PurchaseOrder.vue
+++ b/src/views/PurchaseOrder.vue
@@ -19,11 +19,11 @@
         <ion-list>
           <ion-list-header>{{ $t("Saved mappings") }}</ion-list-header>
           <div>
-            <ion-chip :disabled="!file" outline="true" @click="addFieldMapping()">
+            <ion-chip :disabled="!this.content.length" outline="true" @click="addFieldMapping()">
               <ion-icon :icon="addOutline" />
               <ion-label>{{ $t("New mapping") }}</ion-label>
             </ion-chip>
-            <ion-chip :disabled="!file" v-for="(mapping, index) in fieldMappings ?? []" :key="index" @click="mapFields(mapping)" outline="true">
+            <ion-chip :disabled="!this.content.length" v-for="(mapping, index) in fieldMappings ?? []" :key="index" @click="mapFields(mapping)" outline="true">
               {{ mapping.name }}
             </ion-chip>
           </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As the type for `file` variable has been changed from string to object, hence changed the disabled logic to use content length.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)