### PR TITLE
Improved: Show old missing SKU value (#200)

### DIFF
--- a/src/components/PurchaseOrderDetail.vue
+++ b/src/components/PurchaseOrderDetail.vue
@@ -30,7 +30,7 @@
             </ion-thumbnail>
             <ion-label class="ion-text-wrap">
               <h3>{{ item.pseudoId }}</h3>
-              <p>{{ item.initialSKU }}</p>
+              <p v-if="item.initialSKU">{{ item.initialSKU }}</p>
             </ion-label>
           </ion-item>
           <ion-chip outline class="tablet">

--- a/src/components/PurchaseOrderDetail.vue
+++ b/src/components/PurchaseOrderDetail.vue
@@ -29,7 +29,8 @@
               <Image :src="item.imageUrl" />
             </ion-thumbnail>
             <ion-label class="ion-text-wrap">
-              {{ item.pseudoId }}
+              <h3>{{ item.pseudoId }}</h3>
+              <p>{{ item.initialSKU }}</p>
             </ion-label>
           </ion-item>
           <ion-chip outline class="tablet">

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -56,6 +56,7 @@ const actions: ActionTree<OrderState, RootState> = {
     let original = state.purchaseOrders.original as any;
     const unidentifiedItems = payload.unidentifiedItems.map((item: any) => {
       if(item.updatedSku) {
+        item.initialSKU = item.shopifyProductSKU;
         item.shopifyProductSKU = item.updatedSku;
         parsed[item.orderId] ? parsed[item.orderId].push(item) : parsed[item.orderId] = [item];
         original[item.orderId] ? original[item.orderId].push(item) : original[item.orderId] = [item];

--- a/src/store/modules/stock/actions.ts
+++ b/src/store/modules/stock/actions.ts
@@ -58,6 +58,7 @@ const actions: ActionTree<StockState, RootState> = {
     const parsed = state.items.parsed as any;
     const unidentifiedItems = payload.unidentifiedItems.map((item: any) => {
       if(item.updatedSku) {
+        item.initialSKU = item.shopifyProductSKU;
         item.shopifyProductSKU = item.updatedSku;
         parsed.push(item);
         state.items.original.push(item);

--- a/src/views/InventoryReview.vue
+++ b/src/views/InventoryReview.vue
@@ -49,8 +49,9 @@
           <ion-thumbnail>
             <Image :src="searchedProduct.imageUrl" />
           </ion-thumbnail>
-          <ion-label>
-            {{ searchedProduct.pseudoId }}
+          <ion-label class="ion-text-wrap">
+            <h3>{{ searchedProduct.pseudoId }}</h3>
+            <p>{{ searchedProduct.initialSKU }}</p>
           </ion-label>
         </ion-item>
 
@@ -102,7 +103,8 @@
                 <Image :src="item.imageUrl" />
               </ion-thumbnail>
               <ion-label class="ion-text-wrap">
-                {{ item.pseudoId }}
+                <h3>{{ item.pseudoId }}</h3>
+                <p>{{ item.initialSKU }}</p>
               </ion-label>
             </ion-item>
 

--- a/src/views/InventoryReview.vue
+++ b/src/views/InventoryReview.vue
@@ -51,7 +51,7 @@
           </ion-thumbnail>
           <ion-label class="ion-text-wrap">
             <h3>{{ searchedProduct.pseudoId }}</h3>
-            <p>{{ searchedProduct.initialSKU }}</p>
+            <p v-if="searchedProduct.initialSKU">{{ searchedProduct.initialSKU }}</p>
           </ion-label>
         </ion-item>
 
@@ -104,7 +104,7 @@
               </ion-thumbnail>
               <ion-label class="ion-text-wrap">
                 <h3>{{ item.pseudoId }}</h3>
-                <p>{{ item.initialSKU }}</p>
+                <p v-if="item.initialSKU">{{ item.initialSKU }}</p>
               </ion-label>
             </ion-item>
 


### PR DESCRIPTION
After a missing product has been mapped with a product in the system, the old value that caused the error should still be visible in the secondary text slot so that users can reconcile their data with the original uploaded data.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #200 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)