### PR TITLE
Implemented: Page Selection Persistence for Import App with Side Navigation(#122)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -11,7 +11,6 @@
             <ion-menu-toggle auto-hide="false" v-for="(p, i) in appPages" :key="i">
               <ion-item
                 button
-                @click="selectedIndex = i"
                 router-direction="root"
                 :router-link="p.url"
                 class="hydrated"
@@ -51,11 +50,12 @@ import {
   IonTitle,
   IonToolbar,
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent } from "vue";
 import { mapGetters } from "vuex";
 
 import { albumsOutline, bookmarkOutline, settings, calendar } from "ionicons/icons";
 import { useStore } from "@/store";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "Menu",
@@ -73,13 +73,6 @@ export default defineComponent({
     IonTitle,
     IonToolbar    
   },
-  created() {
-    // When open any specific page it should show that page selected
-    // TODO Find a better way
-    this.selectedIndex = this.appPages.findIndex((page) => {
-      return page.url === this.$router.currentRoute.value.path;
-    })
-  },
   computed: {
     ...mapGetters({
       isUserAuthenticated: 'user/isUserAuthenticated',
@@ -87,18 +80,9 @@ export default defineComponent({
       userProfile: 'user/getUserProfile'
     })
   },
-  watch:{
-    $route (to) {
-      // When logout and login it should point to Oth index
-      // TODO Find a better way
-      if (to.path === '/login') {
-        this.selectedIndex = 0;
-      }
-    },
-  }, 
   setup() {
     const store = useStore();
-    const selectedIndex = ref(0);
+    const router = useRouter();
     const appPages = [
       {
         title: "Inventory",
@@ -123,8 +107,14 @@ export default defineComponent({
         url: "/settings",
         iosIcon: settings,
         mdIcon: settings,
-      },
-    ];
+      }
+    ] as any;
+
+    const selectedIndex = computed(() => {
+      const path = router.currentRoute.value.path
+      return appPages.findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path))
+    })
+
     return {
       selectedIndex,
       appPages,
@@ -133,7 +123,7 @@ export default defineComponent({
       settings,
       store
     };
-  },
+  }
 });
 </script>
 <style scoped>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -87,18 +87,21 @@ export default defineComponent({
       {
         title: "Inventory",
         url: "/inventory",
+        childRoutes: ["/inventory-review"],
         iosIcon: albumsOutline,
         mdIcon: albumsOutline
       },
       {
         title: "Purchase order",
         url: "/purchase-order",
+        childRoutes: ["/purchase-order-review"],
         iosIcon: calendar,
         mdIcon: calendar
       },
       {
         title: "Saved Mappings",
         url: "/saved-mappings",
+        childRoutes: ["/mapping/"],
         iosIcon: bookmarkOutline,
         mdIcon: bookmarkOutline
       },
@@ -108,11 +111,11 @@ export default defineComponent({
         iosIcon: settings,
         mdIcon: settings,
       }
-    ] as any;
+    ];
 
     const selectedIndex = computed(() => {
       const path = router.currentRoute.value.path
-      return appPages.findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path))
+      return appPages.findIndex((screen) => screen.url === path || screen.childRoutes?.includes(path) || screen.childRoutes?.some((route) => path.includes(route)))
     })
 
     return {


### PR DESCRIPTION
### Related Issues
Related Issues: https://github.com/hotwax/dxp-components/issues/122

### Short Description and Why It's Useful
Fixed issue of menu not being enabled for the correct page when using the back button in Import app.

- Removed a watcher from the menu component that checks for route changes.
- Defined a computed property to find the correct index in the menu list.
- Added an entry in the menu component pages to list all the child routes those are not listed in the menu for a specific parent route, using which we have enabled the correct menu in the UI.
- Added a logic for the dynamic child routes in the app.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)