### PR TITLE
Fixed: scrollability in bottom bar on purchase order review page (#229)

### DIFF
--- a/src/views/PurchaseOrderReview.vue
+++ b/src/views/PurchaseOrderReview.vue
@@ -79,7 +79,7 @@
     </ion-content>
 
     <ion-footer>
-      <ion-segment @ionChange="selectAllItems($event.target.value); searchProduct(queryString);" v-model="segmentSelected">
+      <ion-segment scrollable="true" @ionChange="selectAllItems($event.target.value); searchProduct(queryString);" v-model="segmentSelected">
         <ion-segment-button value="all">
           <ion-label>{{ $t("All") }}</ion-label>
         </ion-segment-button>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #229

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added horizontal scrollability in bottom bar on the purchase order review page 


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2023-10-05 11-11-35](https://github.com/hotwax/import/assets/69574321/4b2bc1b4-51fd-44a0-b841-01f4375b8923)

After
![Screenshot from 2023-10-05 11-11-12](https://github.com/hotwax/import/assets/69574321/9cbbe3c5-6a7e-413b-98a8-601de411c9a9)


[Screencast from 05-10-23 11:02:51 AM IST.webm](https://github.com/hotwax/import/assets/69574321/764b63db-82cc-499a-b5c8-9dd4fe626668)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)