### PR TITLE
Improved: support to upload csv file when updating inventory(#279)

### DIFF
--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -8,6 +8,15 @@ const uploadJsonFile = async (payload: any): Promise <any>  => {
       ...payload
     });
 }
+
+const uploadAndImportFile = async (payload: any): Promise <any>  => {
+  return api({
+    url: "uploadAndImportFile",
+    method: "post",
+    ...payload
+  });
+}
+
 const prepareUploadJsonPayload = (request: UploadRequest) => {
       const blob = new Blob([JSON.stringify(request.uploadData)], { type: 'application/json'});
       const formData = new FormData();
@@ -28,5 +37,6 @@ const prepareUploadJsonPayload = (request: UploadRequest) => {
 
 export const UploadService = {
     prepareUploadJsonPayload,
+    uploadAndImportFile,
     uploadJsonFile
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -118,7 +118,7 @@ const jsonToCsv = (file: any, options: JsonToCsvOption = {}) => {
     ...options.encode
   };
   const blob = new Blob([csv], {
-    type: "application/csvcharset=" + encoding 
+    type: "application/csv;charset=" + encoding
   });
   if (options.download) {
     saveAs(blob, options.name ? options.name : "default.csv");

--- a/src/views/PurchaseOrderReview.vue
+++ b/src/views/PurchaseOrderReview.vue
@@ -105,6 +105,7 @@ import MissingSkuModal from "@/components/MissingSkuModal.vue"
 import { UploadService } from "@/services/UploadService";
 import { showToast } from '@/utils';
 import { translate } from "@hotwax/dxp-components";
+import { hasError } from '@/adapter';
 
 export default defineComponent({
   name: 'PurchaseOrderReview',
@@ -277,7 +278,11 @@ export default defineComponent({
                 uploadData,
                 fileName,
                 params
-              })).then(() => {
+              })).then((resp: any) => {
+                if(hasError(resp)) {
+                  throw resp.data
+                }
+
                 this.isPOUploadedSuccessfully = true;
                 showToast(translate("The PO has been uploaded successfully"), [{
                   text: translate('View'),


### PR DESCRIPTION
Added: support to parse json to csv before upload
Added check for error message in api and display a toast message in both inventory and po upload case

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #279 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Changed the file from json to csv format before uploading as multi-threading does not support processing of json files.
Does not made this change for PurchaseOrder upload case as for now we do not enable multithreading support for po's as discussed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)