### PR TITLE
Fixed: event returing on modal dismiss from create mapping modal (#295)

### DIFF
--- a/src/components/CreateMappingModal.vue
+++ b/src/components/CreateMappingModal.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button @click="closeModal"> 
+        <ion-button @click="closeModal()">
           <ion-icon :icon="close" />
         </ion-button>
       </ion-buttons>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#295

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed selected mapping highliting not persisting on dismissing create mapping modal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)