### PR TITLE
Improved: Added the support for using productStore selector from dxp-component(#dxp/193)

### DIFF
--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -17,6 +17,7 @@ import {
   updateInstanceUrl,
   setUserTimeZone,
   getAvailableTimeZones,
+  getEComStores,
   setProductIdentificationPref,
   setUserPreference
 } from '@hotwax/oms-api'
@@ -40,6 +41,7 @@ export {
   updateInstanceUrl,
   setUserTimeZone,
   getAvailableTimeZones,
+  getEComStores,
   setProductIdentificationPref,
   setUserPreference
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import logger from './logger';
 import { dxpComponents } from '@hotwax/dxp-components'
 import { login, logout, loader } from './user-utils';
 import localeMessages from './locales';
-import { fetchGoodIdentificationTypes, getAvailableTimeZones, getConfig, getEComStoresByFacility, getProductIdentificationPref, getUserPreference, initialise, setProductIdentificationPref, setUserPreference, setUserTimeZone } from '@/adapter'
+import { fetchGoodIdentificationTypes, getAvailableTimeZones, getConfig, getEComStores, getEComStoresByFacility, getProductIdentificationPref, getUserPreference, initialise, setProductIdentificationPref, setUserPreference, setUserTimeZone } from '@/adapter'
 
 const app = createApp(App)
   .use(IonicVue, {
@@ -58,6 +58,7 @@ const app = createApp(App)
     appLoginUrl: process.env.VUE_APP_LOGIN_URL as string,
     fetchGoodIdentificationTypes,
     getConfig,
+    getEComStores,
     getEComStoresByFacility,
     getProductIdentificationPref,
     getUserPreference,

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -142,37 +142,11 @@ const getUserPermissions = async (payload: any, token: any): Promise<any> => {
   }
 }
 
-async function getEComStores(): Promise<any> {
-  const params = {
-    "viewSize": 200,
-    "fieldList": ["productStoreId", "storeName"],
-    "entityName": "ProductStore",
-    "distinct": "Y",
-    "noConditionFind": "Y"
-  };
-
-  try {
-    const resp = await api({
-      url: "performFind",
-      method: "get",
-      params
-    }) as any;
-    if(!hasError(resp)) {
-      return Promise.resolve(resp.data.docs?.length ? resp.data.docs : []);
-    } else {
-      throw resp.data
-    }
-  } catch(error) {
-    logger.error(error)
-    return Promise.resolve([])
-  }
-}
 
 export const UserService = {
     createFieldMapping,
     deleteFieldMapping,
     login,
-    getEComStores,
     getFieldMappings,
     getProfile,
     getUserPermissions,

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -65,8 +65,7 @@ const actions: ActionTree<UserState, RootState> = {
         await dispatch('getProfile')
         dispatch('setPreferredDateTimeFormat', process.env.VUE_APP_DATE_FORMAT ? process.env.VUE_APP_DATE_FORMAT : 'MM/dd/yyyy');
 
-        const ecomStores = await UserService.getEComStores()
-        useUserStore().eComStores = ecomStores
+        await useUserStore().getEComStores()
         await useUserStore().getEComStorePreference("SELECTED_BRAND")
         const preferredStore: any = useUserStore().getCurrentEComStore
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/193

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, we were calling the service for fetching product stores independently of any facility from the app.
- Instead, we added support to call the `getEComStores` action of dxp-components, which now essentially fetches from the same service that we moved to oms-api. This service is passed from the app to dxp.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)