### PR TITLE
FIxed: added support to set the defaultZone to userTimeZone(#311)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ import { initialise, resetConfig } from '@/adapter'
 import { showToast } from "@/utils";
 import { translate, useProductIdentificationStore, useUserStore } from "@hotwax/dxp-components";
 import { useRouter } from 'vue-router';
+import { Settings } from 'luxon'
 import logger from '@/logger';
 
 export default defineComponent({
@@ -107,6 +108,10 @@ export default defineComponent({
       await useProductIdentificationStore().getIdentificationPref(currentEComStore.productStoreId)
         .catch((error) => logger.error(error));
     }
+    if (this.userProfile) {
+      // Luxon timezone should be set with the user's selected timezone
+      this.userProfile.userTimeZone && (Settings.defaultZone = this.userProfile.userTimeZone);
+    }
   },
   created() {
     initialise({
@@ -138,6 +143,7 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters({
+      userProfile: 'user/getUserProfile',
       userToken: 'user/getUserToken',
       instanceUrl: 'user/getInstanceUrl'
     })

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -14,6 +14,8 @@ import {
   resetPermissions,
   setPermissions
 } from '@/authorization'
+import { Settings } from 'luxon'
+import store from '@/store'
 
 const actions: ActionTree<UserState, RootState> = {
 
@@ -63,6 +65,11 @@ const actions: ActionTree<UserState, RootState> = {
         commit(types.USER_TOKEN_CHANGED, { newToken: token })
   
         await dispatch('getProfile')
+
+        const userProfile = store.getters['user/getUserProfile']
+        if (userProfile.userTimeZone) {
+          Settings.defaultZone = userProfile.userTimeZone;
+        }
         dispatch('setPreferredDateTimeFormat', process.env.VUE_APP_DATE_FORMAT ? process.env.VUE_APP_DATE_FORMAT : 'MM/dd/yyyy');
 
         const ecomStores = await UserService.getEComStores()
@@ -165,6 +172,7 @@ const actions: ActionTree<UserState, RootState> = {
     const current: any = state.current;
     current.userTimeZone = timeZoneId;
     commit(types.USER_INFO_UPDATED, current);
+    Settings.defaultZone = current.userTimeZone;
   },
 
   /**


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#311 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Here’s the grammatically correct version:  

- Added support to update `defaultZone` to `userTimeZone` when the app mounts, during login, and after updating the user time zone.
- This fixes the issue of honoring the user's time zone.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)