### PR TITLE
Improved: Added a fix by changing the router method for navigation(#320)

### DIFF
--- a/src/views/InventoryReview.vue
+++ b/src/views/InventoryReview.vue
@@ -287,7 +287,7 @@ export default defineComponent({
                     window.open(omsURL, '_blank');
                   }
                 }])
-                this.router.push("/inventory");
+                this.router.replace("/inventory");
                 this.store.dispatch('stock/clearStockItems');
               }).catch(() => {
                 showToast(translate("Something went wrong, please try again"));

--- a/src/views/InventoryReview.vue
+++ b/src/views/InventoryReview.vue
@@ -287,7 +287,7 @@ export default defineComponent({
                     window.open(omsURL, '_blank');
                   }
                 }])
-                this.router.replace("/inventory");
+                this.router.go(-1);
                 this.store.dispatch('stock/clearStockItems');
               }).catch(() => {
                 showToast(translate("Something went wrong, please try again"));

--- a/src/views/PurchaseOrderReview.vue
+++ b/src/views/PurchaseOrderReview.vue
@@ -292,7 +292,7 @@ export default defineComponent({
                     window.open(omsURL, '_blank');
                   }
                 }])
-                this.router.push("/purchase-order");
+                this.router.go(-1);
                 this.store.dispatch('order/updatePurchaseOrders', {parsed: {}, original: {}, unidentifiedItems: []});
               }).catch(() => {
                 showToast(translate("Something went wrong, please try again"));


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#320 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- After returning from the `Review` page to the `Inventory Upload` page and clicking the `Back` button, it navigates back to the `Review` page instead of the `Unified Inventory` page.  
- Added a fix by using the `go` method when navigating to the `Upload` page instead of `push`, because the `push` method stores the route history, which I believe is causing this issue.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)