### PR TITLE
Improved: Added a check to hide the Sync mode option when multithreading is set to 'Y' (#325)

### DIFF
--- a/src/views/AdjustInventoryHistory.vue
+++ b/src/views/AdjustInventoryHistory.vue
@@ -30,7 +30,7 @@
             <ion-item>
               <ion-icon slot="start" :icon="optionsOutline" />
               <ion-select :label="translate('Mode')" interface="popover" :value="configDetails?.executionModeId" @ionChange="updateDataManagerExecutionMode($event.detail.value)">
-                <ion-select-option value="DMC_SYNC">{{ translate("Sync") }}</ion-select-option>
+                <ion-select-option v-if="configDetails?.multiThreading !== 'Y'" value="DMC_SYNC">{{ translate("Sync") }}</ion-select-option>
                 <ion-select-option value="DMC_ASYNC">{{ translate("Async") }}</ion-select-option>
                 <ion-select-option value="DMC_QUEUE">{{ translate("Queued") }}</ion-select-option>
               </ion-select>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#325 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, when multithreading was set to ``Y``, users could change the mode to ``Sync`` from the view history page, which caused conflicts between file uploads and service execution.  
- Now, I have added a check to hide the ``Sync`` option in the mode selection when multithreading is ``Y``.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/44ee427a-2689-4a0d-912b-8bc6d7ae94d7)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)