### PR TITLE
Fixed: Added conversion of quantityOrdered and orderBuffer to numbers for comparison (#338)

### DIFF
--- a/src/components/BulkAdjustmentModal.vue
+++ b/src/components/BulkAdjustmentModal.vue
@@ -107,7 +107,7 @@ export default defineComponent({
       let orderBufferOverflow = false;
       Object.values(this.purchaseOrders.parsed).flat().map((item: any) => {
         if (item.isSelected) {
-          if(item.quantityOrdered <= this.orderBuffer) {
+          if(+item.quantityOrdered <= +this.orderBuffer) {
             item.quantityOrdered = 1;
             orderBufferOverflow = true;
           } else item.quantityOrdered -= this.orderBuffer;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#338 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- After adding the `orderBuffer` for bulk adjustment, comparing it with `quantityOrdered` caused incorrect behavior due to string comparison. So, added conversion of these values to numbers solved the incorrect behaviour.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)