### PR TITLE
Fixed: Rename function not working properly (#352)

### DIFF
--- a/src/views/ScheduledRestockReview.vue
+++ b/src/views/ScheduledRestockReview.vue
@@ -23,7 +23,7 @@
           </ion-item>
           <ion-item :disabled="currentJob?.statusId === 'SERVICE_FINISHED'" lines="none">
             <ion-button v-show="!isJobNameUpdating" color="medium" size="small" fill="outline" @click="editJobName">{{ translate("Rename") }}</ion-button>
-            <ion-button v-show="isJobNameUpdating" color="medium" size="small" fill="outline" @click="updateJobName">{{ translate("Save") }}</ion-button>
+            <ion-button v-show="isJobNameUpdating" color="medium" size="small" fill="outline" @mousedown.prevent @click="updateJobName">{{ translate("Save") }}</ion-button>
             <ion-button color="medium" size="small" fill="outline" @click="cancelInventory">{{ translate("Cancel") }}</ion-button>
           </ion-item>
         </div>
@@ -204,7 +204,7 @@ export default defineComponent({
         'jobId': job.jobId,
         'systemJobEnumId': job.systemJobEnumId,
         'recurrenceTimeZone': this.userProfile.userTimeZone,
-        'tempExprId': job.jobStatus,
+        'tempExprId': job.tempExprId,
         'statusId': "SERVICE_PENDING",
         'runTimeEpoch': '',  // when updating a job clearning the epoch time, as job honors epoch time as runTime and the new job created also uses epoch time as runTime
         'lastModifiedByUserLogin': this.userProfile.userLoginId


### PR DESCRIPTION
### Related Issues

Closes #352

### Short Description and Why It's Useful

This PR fixes the rename functionality for Scheduled Incoming Inventory jobs. The issue had two root causes:

1. **Event Timing Conflict**: When clicking the Save button, the `ionBlur` event on the input field was firing before the click event, causing `cancelRename()` to execute and hide the Save button before the click handler could fire.

2. **Incorrect Field Reference**: The `updateJob` method was using `job.jobStatus` instead of `job.tempExprId` when building the API payload, causing the update to fail.

**Fixes:**
- Added `@mousedown.prevent` to the Save button to prevent the input from losing focus when clicking, allowing the click event to fire properly
- Changed `job.jobStatus` to `job.tempExprId` in the `updateJob` method to use the correct field from the job object

### Screenshots of Visual Changes before/after (If There Are Any)

N/A - No visual changes, only functional fixes.

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)